### PR TITLE
Fix download directories not being saved correctly

### DIFF
--- a/webui.js
+++ b/webui.js
@@ -2243,7 +2243,7 @@ var utWebUI = {
             }
             switch (n) {
                 case "download_directories":
-                    c = c.join("\r\n");
+                    c = c.join('\n');
                     break;
 
                 case "multi_day_transfer_mode_ul":
@@ -2561,7 +2561,7 @@ var utWebUI = {
             }
             switch (m) {
                 case "download_directories":
-                    g = g.split("\n");
+                    g = g.split(/\r?\n/);
                     break;
                 case "seed_ratio":
                     g *= 10;


### PR DESCRIPTION
Previously when there were multiple download directories they would end up saved as a comma separated list on windows, then read back in as a comma separated list and not parsed correctly because the webui expected newline separators.

I changed the split to use regular expressions with an optional carriage return, and the join to use just a newline.
