### PR TITLE
Fix for max_ul_rate and max_dl_rate kilobyte conversions

### DIFF
--- a/webui.js
+++ b/webui.js
@@ -2245,7 +2245,10 @@ var utWebUI = {
                 case "download_directories":
                     c = c.join('\n');
                     break;
-
+				case "max_dl_rate":
+				case "max_ul_rate":
+					c /= 1024;
+					break;
                 case "multi_day_transfer_mode_ul":
                     if (c) {
                         k = 0
@@ -2392,7 +2395,7 @@ var utWebUI = {
                         break;
                     case "seed_time":
                         a /= 60;
-                        break
+                        break;
                 }
                 c.set("value", a)
             }
@@ -2569,6 +2572,10 @@ var utWebUI = {
                 case "seed_time":
                     g *= 60;
                     break;
+				case "max_dl_rate":
+				case "max_ul_rate":
+					g *= 1024;
+					break;
                 case "search_list":
                     g = g.split("\n").map(function(i) {
                         return i.replace(/[\r\n]+/g, "")
@@ -2597,7 +2604,7 @@ var utWebUI = {
                 params[m] = g;
             }
         }
-
+		
         this.request2("webui.setSettings", params, Function.from());
 
         /*var c = Number(window.location.port ? window.location.port : (window.location.protocol == "http:" ? 80 : 443));
@@ -4177,7 +4184,7 @@ var utWebUI = {
         c = "";
         b = this.settings.max_dl_rate || 0;
         if (this.settings["gui.limits_in_statusbar"] && b > 0) {
-            c = "[" + b + " " + L_("SIZE_KB") + g_perSec + "] "
+            c = "[" + b/1024 + " " + L_("SIZE_KB") + g_perSec + "] "
         }
         a = a.replace(/%s/, c);
         d += a;
@@ -4187,7 +4194,7 @@ var utWebUI = {
         c = "";
         b = this.settings.max_ul_rate || 0;
         if (this.settings["gui.limits_in_statusbar"] && b > 0) {
-            c = "[" + b + " " + L_("SIZE_KB") + g_perSec + "] "
+            c = "[" + b/1024 + " " + L_("SIZE_KB") + g_perSec + "] "
         }
         a = a.replace(/%s/, c);
         d += a;

--- a/webui.js
+++ b/webui.js
@@ -2245,10 +2245,10 @@ var utWebUI = {
                 case "download_directories":
                     c = c.join('\n');
                     break;
-				case "max_dl_rate":
-				case "max_ul_rate":
-					c /= 1024;
-					break;
+                case "max_dl_rate":
+                case "max_ul_rate":
+                        c /= 1024;
+                        break;
                 case "multi_day_transfer_mode_ul":
                     if (c) {
                         k = 0
@@ -2572,10 +2572,10 @@ var utWebUI = {
                 case "seed_time":
                     g *= 60;
                     break;
-				case "max_dl_rate":
-				case "max_ul_rate":
-					g *= 1024;
-					break;
+                case "max_dl_rate":
+                case "max_ul_rate":
+                    g *= 1024;
+                    break;
                 case "search_list":
                     g = g.split("\n").map(function(i) {
                         return i.replace(/[\r\n]+/g, "")
@@ -2604,7 +2604,7 @@ var utWebUI = {
                 params[m] = g;
             }
         }
-		
+
         this.request2("webui.setSettings", params, Function.from());
 
         /*var c = Number(window.location.port ? window.location.port : (window.location.protocol == "http:" ? 80 : 443));


### PR DESCRIPTION
This fixes the webui to allow the user to input the size in kB/s while internally using B/s.  The status bar right-click context menu shows the correct values as well, but the ability to set global rate limits from the status bar appears to already be broken before my patch so that functionality is still broken.

This fixes problem number 2 of hadouken/hadouken#166, it still only allows 6 digits but 999999 is now correctly a 1 GB/s limit instead of a 1 MB/s limit.
